### PR TITLE
Refactor travis to scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     global:
         - PHPUNIT_FLAGS="-v --exclude-group installation"
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        - TARGET=test
 
 matrix:
     fast_finish: true
@@ -40,18 +41,10 @@ before_install:
     - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
 
 install:
-    # moved from former install script
-    - composer remove --no-update --dev friendsofphp/php-cs-fixer
-    # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-    - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
-    - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
-    - ./vendor/bin/simple-phpunit install
+    - if [ -x .travis/install_${TARGET}.sh ]; then .travis/install_${TARGET}.sh; fi;
 
 script:
-    - composer validate --strict --no-check-lock
-    # simple-phpunit is the PHPUnit wrapper provided by the PHPUnit Bridge component and
-    # it helps with testing legacy code and deprecations (composer require symfony/phpunit-bridge)
-    - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
+    - if [ -x .travis/script_${TARGET}.sh ]; then .travis/script_${TARGET}.sh; fi;
 
 branches:
     only: master

--- a/.travis/install_test.sh
+++ b/.travis/install_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+composer remove --no-update --dev friendsofphp/php-cs-fixer
+
+if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
+
+composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
+
+./vendor/bin/simple-phpunit install

--- a/.travis/script_install.sh
+++ b/.travis/script_install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+composer validate --strict --no-check-lock
+
+./vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Fixed tickets | <!-- comma-separated list of tickets fixed by the PR, if any -->
| License       | MIT

To be able to add a case for docs without running phpunit tests, I refactored back to scripts as explained here https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues/43.