### PR TITLE
Return extension in bundle

### DIFF
--- a/src/FOSCKEditorBundle.php
+++ b/src/FOSCKEditorBundle.php
@@ -13,6 +13,7 @@ namespace FOS\CKEditorBundle;
 
 use FOS\CKEditorBundle\DependencyInjection\Compiler\ResourceCompilerPass;
 use FOS\CKEditorBundle\DependencyInjection\Compiler\TemplatingCompilerPass;
+use FOS\CKEditorBundle\DependencyInjection\FOSCKEditorExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,5 +30,10 @@ class FOSCKEditorBundle extends Bundle
         $container
             ->addCompilerPass(new ResourceCompilerPass())
             ->addCompilerPass(new TemplatingCompilerPass());
+    }
+
+    public function getContainerExtension()
+    {
+        return new FOSCKEditorExtension();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | <!-- comma-separated list of tickets fixed by the PR, if any -->
| License       | MIT

After I started on  #61 I saw some tests are failing:

https://github.com/fsi-open/resource-repository-bundle/pull/67
https://github.com/fsi-open/admin-translatable-bundle/pull/77

Here is a fix, I guess we would miss this if it weren't for @fsi-open