### PR TITLE
Correct the typo

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -11,7 +11,7 @@ Update composer.json
 .. code-block:: bash
 
     composer remove egeloen/ckeditor-bundle
-    composer require friensofsymfony/ckeditor-bundle
+    composer require friendsofsymfony/ckeditor-bundle
 
 Update bundle definition
 ------------------------


### PR DESCRIPTION
Fixed a typo in the composer's comand from `friensofsymfony` to `friendsofsymfony`
