### PR TITLE
Escape the backslashes

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,0 +1,42 @@
+---
+name: 🐞 Bug Report
+about: Something is broken? 🔨
+---
+
+<!--
+    Before you open an issue, make sure this one does not already exist.
+    Please also read the "guidelines for contributing" link above before posting.
+-->
+
+<!--
+    If you are reporting a bug, please try to fill in the following.
+    Otherwise remove it.
+-->
+
+### Environment
+
+#### Symfony packages
+
+```
+$ composer show --latest 'symfony/*'
+```
+
+## Subject
+
+<!--
+    Give here as many details as possible.
+    Next sections are for ERRORS only.
+-->
+
+## Steps to reproduce
+
+## Expected results
+
+## Actual results
+
+<!--
+    If it's an error message or piece of code, use code block tags,
+    and make sure you provide the whole stack trace(s),
+    not just the first error message you can see.
+    More details here: https://github.com/symfony-cmf/Testing/blob/master/CONTRIBUTING.md#issues
+-->

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -1,0 +1,8 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and may want to implement it 🙂)!
+---
+
+## Feature Request
+
+<!-- Provide a summary of the feature. -->

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,7 @@
+---
+name: ❓ Support Question
+about: If you have a question 💬, please check out our Slack or StackOverflow!
+---
+
+Hi, we try to keep Github issues for bug reports and feature requests only.
+If you have a question, please ask it on Stack Overflow or on #ckeditor on [the symfony-devs slack](https://symfony.com/slack-invite).

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,22 @@ matrix:
         - php: 7.2
           env: DEPENDENCIES="symfony/lts:^3"
 
-          # Latest commit to master
+          #doc
+        - php: 7.2
+          env: TARGET=docs
+
         - php: 7.2
           env: STABILITY="dev"
 
-          #doc
-        - php: '7.2'
-          env: TARGET=docs
+        - php: 7.1
+          env: TARGET=phpstan LEVEL=0
+
+        - php: 7.1
+          env: TARGET=phpstan LEVEL=7
 
     allow_failures:
-          # Dev-master is allowed to fail.
         - env: STABILITY="dev"
+        - env: TARGET=phpstan LEVEL=7
 
 before_install:
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,3 @@ script:
     - if [ -x .travis/script_${TARGET}.sh ]; then .travis/script_${TARGET}.sh; fi;
 
 after_success: .travis/success.sh
-
-branches:
-    only: master

--- a/.travis/script_phpstan.sh
+++ b/.travis/script_phpstan.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+composer require phpstan/phpstan
+php vendor/bin/phpstan analyse -l ${LEVEL} src tests -c phpstan.neon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,12 @@
 # CHANGELOG
 
+## [1.1.0](https://github.com/FriendsOfSymfony/FOSCKEditorBundle/compare/1.0.0...1.1.0) - 2018-05-25
+### Added
+- Deprecation message for IvoryCKEditorBundle
+
+### Changed
+- The command is now lazy loaded in Symfony 3.4+
+
+### Fixed
+- `ckeditor:install` command not working with `--no-interaction`
+

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,9 @@
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
         "twig/twig": "^1.34 || ^2.0"
     },
+    "replace": {
+        "egeloen/ckeditor-bundle": "^6.0"
+    },
     "suggest": {
         "egeloen/form-extra-bundle": "Allows to load CKEditor asynchronously"
     },

--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,6 @@
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
         "twig/twig": "^1.34 || ^2.0"
     },
-    "replace": {
-        "egeloen/ckeditor-bundle": "^6.0"
-    },
     "suggest": {
         "egeloen/form-extra-bundle": "Allows to load CKEditor asynchronously"
     },

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "autoload": {

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,8 +61,14 @@ If you're using Symfony <= 2.8:
 
     $ php app/console assets:install web
 
-If you're using Symfony >= 3.0:
+If you're using Symfony >= 3.0 without Symfony Flex:
 
 .. code-block:: bash
 
     $ php bin/console assets:install web
+
+If you're using Symfony Flex:
+
+.. code-block:: bash
+
+    $ php bin/console assets:install public

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -8,31 +8,10 @@ TL;DR: Check how we migrated `SonataFormatterBundle`_
 Update composer.json
 --------------------
 
-Replace:
-
-.. code-block:: json
-
-    {
-        "require": {
-            "egeloen/ckeditor-bundle": "*"
-        }
-    }
-
-With:
-
-.. code-block:: json
-
-    {
-        "require": {
-            "friendsofsymfony/ckeditor-bundle": "^1.0"
-        }
-    }
-
-And then install package:
-
 .. code-block:: bash
 
-    composer install
+    composer remove egeloen/ckeditor-bundle
+    composer require friendsofsymfony/ckeditor-bundle
 
 Update bundle definition
 ------------------------

--- a/docs/usage/template.rst
+++ b/docs/usage/template.rst
@@ -6,7 +6,7 @@ Enable the Templates Plugin
 
 The bundle offers you the ability to manage extra templates. To use this
 feature, you need to enable the ``templates`` plugins shipped with the bundle.
-You can define iy globally in your configuration:
+You can define it globally in your configuration:
 
 .. code-block:: yaml
 

--- a/docs/usage/toolbar.rst
+++ b/docs/usage/toolbar.rst
@@ -104,4 +104,4 @@ you want to just override one part of a configuration, just override it:
 .. note::
 
     If you want the full list of built-in items, check the
-    `FOS\CKEditorBundle\Model\ToolbarManager` class.
+    `FOS\\CKEditorBundle\\Model\\ToolbarManager` class.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    bootstrap: %currentWorkingDirectory%/tests/autoload.php
+    excludes_analyse:
+        - %currentWorkingDirectory%/src/Resources/views/Form/*html.php
+        - %currentWorkingDirectory%/tests/autoload.php
+    ignoreErrors:
+        - '#AbstractTestCase::getMock()#'

--- a/src/Command/CKEditorInstallerCommand.php
+++ b/src/Command/CKEditorInstallerCommand.php
@@ -15,7 +15,6 @@ namespace FOS\CKEditorBundle\Command;
 use FOS\CKEditorBundle\Installer\CKEditorInstaller;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -160,9 +159,9 @@ EOF
      */
     private function createNotifier(InputInterface $input, OutputInterface $output)
     {
-        $clear = $this->createProgressBar($output);
-        $download = $this->createProgressBar($output);
-        $extract = $this->createProgressBar($output);
+        $clear = new ProgressBar($output);
+        $download = new ProgressBar($output);
+        $extract = new ProgressBar($output);
 
         return function ($type, $data) use ($input, $output, $clear, $download, $extract) {
             switch ($type) {
@@ -209,7 +208,7 @@ EOF
                     break;
 
                 case CKEditorInstaller::NOTIFY_CLEAR_SIZE:
-                    $this->startProgressBar($clear, $output, $data);
+                    $clear->start($data);
 
                     break;
 
@@ -224,12 +223,12 @@ EOF
                     break;
 
                 case CKEditorInstaller::NOTIFY_DOWNLOAD_PROGRESS:
-                    $this->advanceProgressBar($download, $data);
+                    $download->advance($data);
 
                     break;
 
                 case CKEditorInstaller::NOTIFY_DOWNLOAD_SIZE:
-                    $this->startProgressBar($download, $output, $data);
+                    $download->start($data);
 
                     break;
 
@@ -249,7 +248,7 @@ EOF
                     break;
 
                 case CKEditorInstaller::NOTIFY_EXTRACT_SIZE:
-                    $this->startProgressBar($extract, $output, $data);
+                    $extract->start($data);
 
                     break;
             }
@@ -348,7 +347,7 @@ EOF
         $result = $helper->ask(
             $input,
             $output,
-            new ChoiceQuestion($question, $choices, $choices[$default])
+            new ChoiceQuestion($question, $choices, $default)
         );
 
         $output->writeln('');
@@ -357,37 +356,8 @@ EOF
     }
 
     /**
+     * @param ProgressBar     $progress
      * @param OutputInterface $output
-     *
-     * @return ProgressBar|ProgressHelper
-     */
-    private function createProgressBar(OutputInterface $output)
-    {
-        return class_exists(ProgressBar::class) ? new ProgressBar($output) : new ProgressHelper();
-    }
-
-    /**
-     * @param ProgressBar|ProgressHelper $progress
-     * @param OutputInterface            $output
-     * @param int|null                   $max
-     */
-    private function startProgressBar($progress, OutputInterface $output, $max = null)
-    {
-        class_exists(ProgressBar::class) ? $progress->start($max) : $progress->start($output, $max);
-    }
-
-    /**
-     * @param ProgressBar|ProgressHelper $progress
-     * @param int                        $current
-     */
-    private function advanceProgressBar($progress, $current)
-    {
-        class_exists(ProgressBar::class) ? $progress->setProgress($current) : $progress->setCurrent($current);
-    }
-
-    /**
-     * @param ProgressBar|ProgressHelper $progress
-     * @param OutputInterface            $output
      */
     private function finishProgressBar($progress, OutputInterface $output)
     {

--- a/src/DependencyInjection/FOSCKEditorExtension.php
+++ b/src/DependencyInjection/FOSCKEditorExtension.php
@@ -46,6 +46,15 @@ class FOSCKEditorExtension extends ConfigurableExtension
                 ->clearTag('form.type')
                 ->addTag('form.type', ['alias' => 'ckeditor']);
         }
+
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (isset($bundles['IvoryCKEditorBundle'])) {
+            @trigger_error(
+                "IvoryCKEditorBundle isn't maintained anymore and should be replaced with FOSCKEditorBundle.",
+                E_USER_DEPRECATED
+            );
+        }
     }
 
     /**

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="fos_ck_editor.command.installer" class="FOS\CKEditorBundle\Command\CKEditorInstallerCommand">
             <argument type="service" id="fos_ck_editor.installer" />
-            <tag name="console.command" />
+            <tag name="console.command" command="ckeditor:install" />
         </service>
     </services>
 </container>

--- a/src/Resources/views/Form/_ckeditor_javascript.html.php
+++ b/src/Resources/views/Form/_ckeditor_javascript.html.php
@@ -1,3 +1,36 @@
+<?php
+
+/*
+ * This file is part of the FOSCKEditor Bundle.
+ *
+ * (c) 2018 - present  Friends of Symfony
+ * (c) 2009 - 2017     Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use FOS\CKEditorBundle\Renderer\CKEditorRendererInterface;
+
+/*
+ * @var CKEditorRendererInterface[] $view
+ * @var string $id
+ * @var string $base_path
+ * @var string $js_path
+ * @var string $jquery_path
+ * @var bool $jquery
+ * @var bool $require_js
+ * @var string[][] $styles
+ * @var string[][] $plugins
+ * @var string[][] $templates
+ * @var string $auto_inline
+ * @var string $input_sync
+ * @var string $inline
+ * @var string $filebrowsers
+ * @var array $config
+ */
+
+?>
 <?php if ($autoload) : ?>
     <script type="text/javascript">
         var CKEDITOR_BASEPATH = "<?php echo $view['fos_ckeditor']->renderBasePath($base_path); ?>";

--- a/src/Resources/views/Form/ckeditor_javascript.html.php
+++ b/src/Resources/views/Form/ckeditor_javascript.html.php
@@ -1,3 +1,20 @@
+<?php
+
+/*
+ * This file is part of the FOSCKEditor Bundle.
+ *
+ * (c) 2018 - present  Friends of Symfony
+ * (c) 2009 - 2017     Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @var bool
+ * @var bool $async
+ */
+?>
 <?php if ($enable && $async) : ?>
     <?php include __DIR__.'/_ckeditor_javascript.html.php'; ?>
 <?php endif; ?>

--- a/src/Resources/views/Form/ckeditor_widget.html.php
+++ b/src/Resources/views/Form/ckeditor_widget.html.php
@@ -1,3 +1,26 @@
+<?php
+
+/*
+ * This file is part of the FOSCKEditor Bundle.
+ *
+ * (c) 2018 - present  Friends of Symfony
+ * (c) 2009 - 2017     Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @var CKEditorRendererInterface|FormView[]
+ * @var object                               $form
+ * @var string                               $value
+ * @var bool                                 $enable
+ * @var bool                                 $async
+ */
+use FOS\CKEditorBundle\Renderer\CKEditorRendererInterface;
+use Symfony\Component\Form\FormView;
+
+?>
 <textarea <?php echo $view['form']->block($form, 'attributes'); ?>><?php echo htmlspecialchars($value); ?></textarea>
 
 <?php if ($enable && !$async) : ?>

--- a/tests/DependencyInjection/AbstractFOSCKEditorExtensionTest.php
+++ b/tests/DependencyInjection/AbstractFOSCKEditorExtensionTest.php
@@ -83,7 +83,7 @@ abstract class AbstractFOSCKEditorExtensionTest extends AbstractTestCase
         $this->container->set('twig.form.renderer', $this->formRenderer);
         $this->container->set('request_stack', $this->requestStack);
         $this->container->set('templating', $this->templating);
-
+        $this->container->setParameter('kernel.bundles', []);
         $this->container->registerExtension($extension = new FOSCKEditorExtension());
         $this->container->loadFromExtension($extension->getAlias());
 

--- a/tests/DependencyInjection/AbstractFOSCKEditorExtensionTest.php
+++ b/tests/DependencyInjection/AbstractFOSCKEditorExtensionTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Templating\EngineInterface;
-use Symfony\Component\Templating\Helper\CoreAssetsHelper;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -39,7 +38,7 @@ abstract class AbstractFOSCKEditorExtensionTest extends AbstractTestCase
     private $container;
 
     /**
-     * @var Packages|CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject
+     * @var Packages|\PHPUnit_Framework_MockObject_MockObject
      */
     private $packages;
 

--- a/tests/DependencyInjection/FOSCKEditorExtensionTest.php
+++ b/tests/DependencyInjection/FOSCKEditorExtensionTest.php
@@ -19,6 +19,7 @@ class FOSCKEditorExtensionTest extends AbstractExtensionTestCase
 {
     public function testHasServiceDefinitionForTemplatingAlias()
     {
+        $this->container->setParameter('kernel.bundles', []);
         $this->load();
 
         $taggedServices = $this->container->findTaggedServiceIds('templating.helper');


### PR DESCRIPTION
The ToolbarManager class namespace had single backslashes which were not visible when viewing the page

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
