### PR TITLE
escape backslashes in ToolbarManager class namespace

### DIFF
--- a/docs/usage/toolbar.rst
+++ b/docs/usage/toolbar.rst
@@ -104,4 +104,4 @@ you want to just override one part of a configuration, just override it:
 .. note::
 
     If you want the full list of built-in items, check the
-    `FOS\CKEditorBundle\Model\ToolbarManager` class.
+    `FOS\\CKEditorBundle\\Model\\ToolbarManager` class.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
