### PR TITLE
Indicate trailing slashes in plugin directory config

### DIFF
--- a/docs/usage/plugin.rst
+++ b/docs/usage/plugin.rst
@@ -30,7 +30,7 @@ globally in your configuration:
                 extraPlugins: "wordcount"
         plugins:
             wordcount:
-                path:     "/bundles/mybundle/wordcount/"
+                path:     "/bundles/mybundle/wordcount/" # with trailing slash
                 filename: "plugin.js"
 
 Or you can do it in your widget:
@@ -43,7 +43,7 @@ Or you can do it in your widget:
         ),
         'plugins' => array(
             'wordcount' => array(
-                'path'     => '/bundles/mybundle/wordcount/',
+                'path'     => '/bundles/mybundle/wordcount/', // with trailing slash
                 'filename' => 'plugin.js',
             ),
         ),


### PR DESCRIPTION
Relates to issue #128. In Symfony directories are usually specified without trailing slashes, so I feel it might be important to insist on the trailing slash here.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | Issue #128 
| License       | MIT
