### PR TITLE
Exception marker

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,8 @@
 UPGRADE FROM 1.x to 2.0
 =======================
 
+Marker exception is now an interface that implements throwable.
+
 All Model Managers have been removed.
 Not used exceptions have been removed.
 

--- a/src/Exception/ConfigException.php
+++ b/src/Exception/ConfigException.php
@@ -12,10 +12,12 @@
 
 namespace FOS\CKEditorBundle\Exception;
 
+use RuntimeException;
+
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ConfigException extends Exception
+class ConfigException extends RuntimeException implements FOSCKEditorException
 {
     public static function configDoesNotExist(string $name): self
     {

--- a/src/Exception/FOSCKEditorException.php
+++ b/src/Exception/FOSCKEditorException.php
@@ -12,11 +12,11 @@
 
 namespace FOS\CKEditorBundle\Exception;
 
-use Exception as BaseException;
+use Throwable;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class Exception extends BaseException
+interface FOSCKEditorException extends Throwable
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

I think that exception marker should be an interface or at least an abstract class, rather than an empty class extending php exception. Only one exception is changed because other ones will be removed.