### PR TITLE
Symfony/assets is mandatory dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-zip": "*",
+        "symfony/asset": "^2.7 || ^3.0 || ^4.0",
         "symfony/config": "^2.7 || ^3.0 || ^4.0",
         "symfony/dependency-injection": "^2.7 || ^3.0 || ^4.0",
         "symfony/expression-language": "^2.7 || ^3.0 || ^4.0",
@@ -40,7 +41,6 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.0 || ^2.0",
         "phpunit/phpunit": "^5.0 || ^6.0",
         "sensio/distribution-bundle": "^3.0.12 || ^4.0 || ^5.0",
-        "symfony/asset": "^2.7 || ^3.0 || ^4.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0",
         "symfony/phpunit-bridge": "^4.0",
         "symfony/templating": "^2.7 || ^3.0 || ^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | closes #146
| License       | MIT

After #145 issue I saw that assets are not mandatory even if we require it in code.
