### PR TITLE
Fixed zip archive download behind proxy

### DIFF
--- a/src/Installer/CKEditorInstaller.php
+++ b/src/Installer/CKEditorInstaller.php
@@ -185,9 +185,12 @@ final class CKEditorInstaller
         $proxy = getenv('https_proxy') ?: getenv('http_proxy');
 
         if ($proxy) {
-            $context['proxy'] = $proxy;
-            $context['request_fulluri'] = (bool) getenv('https_proxy_request_fulluri') ?:
-                getenv('http_proxy_request_fulluri');
+            $proxyUrl = parse_url($proxy);
+            $context['http'] = [
+                'proxy' => 'tcp://'.$proxyUrl['host'].':'.$proxyUrl['port'],
+                'request_fulluri' => (bool) getenv('https_proxy_request_fulluri') ?:
+                    getenv('http_proxy_request_fulluri'),
+            ];
         }
 
         return stream_context_create($context, [

--- a/tests/Installer/CKEditorInstallerTest.php
+++ b/tests/Installer/CKEditorInstallerTest.php
@@ -39,7 +39,7 @@ class CKEditorInstallerTest extends TestCase
     {
         $this->installer = new CKEditorInstaller();
         $this->path = __DIR__.'/../../src/Resources/public';
-        $this->proxy = 'http://178.32.218.91:80';
+        $this->proxy = 'http://50.224.173.190:8080';
 
         $this->tearDown();
     }


### PR DESCRIPTION
The '`proxy`' and '`request_fulluri`' options for `stream_context_create `must be wrapped inside an '`http`' associative array (see http://php.net/manual/en/function.stream-context-create.php: "_Must be an associative array of associative arrays in the format_ `$arr['wrapper']['option'] = $value`").
And the proxy url must be in the form: 'tcp:://<proxy_host>:<proxy_port>'.

There is already a similar PR (https://github.com/FriendsOfSymfony/FOSCKEditorBundle/pull/113), but I don't know how to change it.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #111 
| License       | MIT
