### PR TITLE
Include CSS files when copying files with Encore

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,6 +71,7 @@ Once installed, add the following lines to your Webpack Encore configuration fil
 .. code-block:: javascript
 
     // webpack.config.js
+    var path = require('path');
     var Encore = require('@symfony/webpack-encore');
 
     Encore
@@ -82,6 +83,7 @@ Once installed, add the following lines to your Webpack Encore configuration fil
             {from: './node_modules/ckeditor/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
             {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'}
         ])
+        .addLoader({test: /\.json$/i, include: [path.resolve(__dirname, 'node_modules/ckeditor')], loader: 'raw-loader', type: 'javascript/auto'})
     ;
 
 Then, override the bundle's configuration to point to the new CKEditor path:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -76,7 +76,7 @@ Once installed, add the following lines to your Webpack Encore configuration fil
     Encore
         // ...
         .copyFiles([
-            {from: './node_modules/ckeditor/', to: 'ckeditor/[path][name].[ext]', pattern: '/\.js$/'},
+            {from: './node_modules/ckeditor/', to: 'ckeditor/[path][name].[ext]', pattern: /\.(js|css)$/},
             {from: './node_modules/ckeditor/lang', to: 'ckeditor/lang/[path][name].[ext]'},
             {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'}
         ])

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -66,7 +66,7 @@ You can by running this command:
     # if you are using Yarn as package manager
     $ yarn add ckeditor@^4.0.0
 
-Once installed, add the following lines to your Webpack Encore configuration file:
+Once installed, add the following lines to your Webpack Encore configuration file (this excludes the samples directory from the ckeditor node module):
 
 .. code-block:: javascript
 
@@ -76,8 +76,10 @@ Once installed, add the following lines to your Webpack Encore configuration fil
     Encore
         // ...
         .copyFiles([
-            {from: './node_modules/ckeditor/', to: 'ckeditor/[path][name].[ext]', pattern: /\.(js|css)$/},
+            {from: './node_modules/ckeditor/', to: 'ckeditor/[path][name].[ext]', pattern: /\.(js|css)$/, includeSubdirectories: false},
+            {from: './node_modules/ckeditor/adapters', to: 'ckeditor/adapters/[path][name].[ext]'},
             {from: './node_modules/ckeditor/lang', to: 'ckeditor/lang/[path][name].[ext]'},
+            {from: './node_modules/ckeditor/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
             {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'}
         ])
     ;


### PR DESCRIPTION
Without the CSS files being copied into the build directory, a bunch of requests fail as they are missing. This change adds them to the build output.

Edit: I've also adjusted the rules to no longer include the `samples` directory.

| Q             | A
| ------------- | ---
| Bug fix?      | _yes_
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | <!-- comma-separated list of tickets fixed by the PR, if any -->
| License       | MIT
