### PR TITLE
Comment temporary workaround for JSON files copy

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,7 +71,6 @@ Once installed, add the following lines to your Webpack Encore configuration fil
 .. code-block:: javascript
 
     // webpack.config.js
-    var path = require('path');
     var Encore = require('@symfony/webpack-encore');
 
     Encore
@@ -83,7 +82,8 @@ Once installed, add the following lines to your Webpack Encore configuration fil
             {from: './node_modules/ckeditor/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
             {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'}
         ])
-        .addLoader({test: /\.json$/i, include: [path.resolve(__dirname, 'node_modules/ckeditor')], loader: 'raw-loader', type: 'javascript/auto'})
+        // Uncomment the following line if you are using Webpack Encore <= 0.24
+        // .addLoader({test: /\.json$/i, include: [require('path').resolve(__dirname, 'node_modules/ckeditor')], loader: 'raw-loader', type: 'javascript/auto'})
     ;
 
 Then, override the bundle's configuration to point to the new CKEditor path:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

In #177 a small workaround had to be added to the `webpack.config.js` file to allow the copy of JSON files.

Since this has been fixed in Encore 0.25.0 (see https://github.com/symfony/webpack-encore/commit/7bec5742cf1668694ba6e767107f6520c62039ea) that line shouldn't be needed anymore.