### PR TITLE
Add support for custom builds

### DIFF
--- a/docs/usage/ckeditor.rst
+++ b/docs/usage/ckeditor.rst
@@ -61,6 +61,17 @@ You can choose which CKEditor release (full, standard or basic) to download:
 
     $ php bin/console ckeditor:install --release=basic
 
+CKEditor Custom Build
+~~~~~~~~~~~~~~~~~~~~~
+
+It's also possible to use custom build generated using CKEditor online builder:
+https://ckeditor.com/cke4/builder. Download ZIP archive from CKEditor website
+and use your custom build ID from `build-config.js` file:
+
+.. code-block:: bash
+
+    $ php bin/console ckeditor:install --release=custom --custom-build-id=574a82a0d3e9226d94b0e91d10eaa372
+
 CKEditor Version
 ~~~~~~~~~~~~~~~~
 

--- a/src/Command/CKEditorInstallerCommand.php
+++ b/src/Command/CKEditorInstallerCommand.php
@@ -50,7 +50,13 @@ final class CKEditorInstallerCommand extends Command
                 'release',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'CKEditor release (basic, standard or full)'
+                'CKEditor release (basic, standard, full or custom)'
+            )
+            ->addOption(
+                'custom-build-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'CKEditor custom build ID'
             )
             ->addOption('tag', null, InputOption::VALUE_OPTIONAL, 'CKEditor tag (x.y.z or latest)')
             ->addOption(
@@ -89,6 +95,10 @@ You can install a specific version:
 
   <info>php %command.full_name% --tag=4.7.0</info>
 
+You can install custom build generated on https://ckeditor.com/cke4/builder:
+
+  <info>php %command.full_name% --release=custom --custom-build-id=574a82a0d3e9226d94b0e91d10eaa372</info>
+
 If there is a previous CKEditor installation detected, 
 you can control how it should be handled in non-interactive mode:
 
@@ -126,6 +136,10 @@ EOF
 
         if ($input->hasOption('release')) {
             $options['release'] = $input->getOption('release');
+        }
+
+        if ($input->hasOption('custom-build-id')) {
+            $options['custom_build_id'] = $input->getOption('custom-build-id');
         }
 
         if ($input->hasOption('tag')) {

--- a/src/Installer/CKEditorInstaller.php
+++ b/src/Installer/CKEditorInstaller.php
@@ -239,12 +239,12 @@ final class CKEditorInstaller
         $offset = 20 + strlen($options['release']) + strlen($options['version']);
 
         for ($i = 0; $i < $zip->numFiles; ++$i) {
-            $this->extractFile(
-                $file = $zip->getNameIndex($i),
-                substr($file, $offset),
-                $path,
-                $options
-            );
+            $filename = $zip->getNameIndex($i);
+            $isDirectory = ('/' === substr($filename, -1, 1));
+
+            if (!$isDirectory) {
+                $this->extractFile($filename, substr($filename, $offset), $path, $options);
+            }
         }
 
         $zip->close();
@@ -270,12 +270,9 @@ final class CKEditorInstaller
             }
         }
 
-        if ('/' === substr($from, -1)) {
-            if (!is_dir($to) && !@mkdir($to)) {
-                throw $this->createException(sprintf('Unable to create the directory "%s".', $to));
-            }
-
-            return;
+        $targetDirectory = dirname($to);
+        if (!is_dir($targetDirectory) && !@mkdir($targetDirectory, 0777, true)) {
+            throw $this->createException(sprintf('Unable to create the directory "%s".', $targetDirectory));
         }
 
         if (!@copy($from, $to)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues/180
| License       | MIT

This PR adds support for custom builds from https://ckeditor.com/cke4/builder to ckeditor:install console command. Usage:
```
bin/console ckeditor:install --release=custom --custom-build-id=574a82a0d3e9226d94b0e91d10eaa372
```
To use this feature go to https://ckeditor.com/cke4/builder, generate your own build, download it and get your custom build ID from build-config.js file.