### PR TITLE
Builder config

### DIFF
--- a/docs/usage/language.rst
+++ b/docs/usage/language.rst
@@ -29,6 +29,6 @@ Or you can do it in your widget:
 
 .. code-block:: php
 
-    $builder->add('field', 'ckeditor', 'config' => array(
+    $builder->add('field', 'ckeditor', array('config' => array(
         'language' => 'fr',
-    ));
+    )));


### PR DESCRIPTION
Array is missing for the config element

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
