### PR TITLE
Replaced app/config/config.yml

### DIFF
--- a/docs/usage/toolbar.rst
+++ b/docs/usage/toolbar.rst
@@ -11,7 +11,7 @@ easily switch the toolbar configuration by using the ``full``, ``standard`` or
 
 .. code-block:: yaml
 
-    # app/config/config.yml
+    # config/packages/fos_ck_editor.yaml
     fos_ck_editor:
         configs:
             my_config:
@@ -37,7 +37,7 @@ only available in your configuration.
 
 .. code-block:: yaml
 
-    # app/config/config.yml
+    # config/packages/fos_ck_editor.yaml
     fos_ck_editor:
         configs:
             my_config_1:


### PR DESCRIPTION
Replaced app/config/config.yml by config/packages/fos_ck_editor.yaml : correct place in current version, and tried. 
See https://symfony.com/doc/master/bundles/EasyAdminBundle/integration/ivoryckeditorbundle.html#customizing-the-rich-text-editor

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | <!-- comma-separated list of tickets fixed by the PR, if any -->
| License       | MIT
