### PR TITLE
Twig 3.x support, fix minimum Twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/property-access": "^3.4 || ^4.0",
         "symfony/routing": "^3.4 || ^4.0",
         "symfony/twig-bundle": "^3.4 || ^4.0",
-        "twig/twig": "^2.0"
+        "twig/twig": "^2.4 || ^3.0"
     },
     "conflict": {
         "sebastian/environment": "<1.3.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A
| License       | MIT

Twig 3.x was released, this bundle should support it.  It looks like the Twig extension class is already good to go, the new major version just needed to be added to the list.

I also raised the Twig minimum to match when the namespaced Twig classes were introduced (1.34 and 2.4 is when those came).