### PR TITLE
Fix file excludes with leading slashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     global:
         - PHPUNIT_FLAGS="-v"
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        - SYMFONY_PHPUNIT_VERSION="7"
         - TARGET=test
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     global:
         - PHPUNIT_FLAGS="-v"
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
-        - SYMFONY_PHPUNIT_VERSION="7"
+        - SYMFONY_PHPUNIT_VERSION="6.5"
         - TARGET=test
 
 matrix:
@@ -25,10 +25,9 @@ matrix:
             - SYMFONY_PHPUNIT_VERSION="5.7.26"
 
           # Coverage
-        - php: 7.1
+        - php: 7.4
           env:
             - PHPUNIT_FLAGS="-v --coverage-clover build/logs/clover.xml"
-            - SYMFONY_PHPUNIT_VERSION="6.5"
             - COVERAGE=true
 
           # Test LTS version. This makes sure we do not use Symfony packages with version greater
@@ -40,10 +39,9 @@ matrix:
         - php: 7.2
           env: TARGET=docs
 
-        - php: 7.2
+        - php: 7.4
           env:
             - STABILITY="dev"
-            - SYMFONY_PHPUNIT_VERSION="6.5"
 
         - php: 7.1
           env: TARGET=phpstan LEVEL=7

--- a/src/Installer/CKEditorInstaller.php
+++ b/src/Installer/CKEditorInstaller.php
@@ -150,11 +150,7 @@ final class CKEditorInstaller
                 }
 
                 if (!$success) {
-                    throw $this->createException(sprintf(
-                        'Unable to remove the %s "%s".',
-                        $dir ? 'directory' : 'file',
-                        $filePath
-                    ));
+                    throw $this->createException(sprintf('Unable to remove the %s "%s".', $dir ? 'directory' : 'file', $filePath));
                 }
             }
 

--- a/src/Installer/CKEditorInstaller.php
+++ b/src/Installer/CKEditorInstaller.php
@@ -295,7 +295,7 @@ final class CKEditorInstaller
         $to = $options['path'].'/'.$rewrite;
 
         foreach ($options['excludes'] as $exclude) {
-            if (0 === strpos($rewrite, $exclude)) {
+            if (0 === strpos(ltrim($rewrite, '\\/'), $exclude)) {
                 return;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | -
| License       | MIT


Tests were failing due to leading slash `/` in file names during extraction. This should fix issues with #201 and #202.
