### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,7 +80,8 @@ Once installed, add the following lines to your Webpack Encore configuration fil
             {from: './node_modules/ckeditor/adapters', to: 'ckeditor/adapters/[path][name].[ext]'},
             {from: './node_modules/ckeditor/lang', to: 'ckeditor/lang/[path][name].[ext]'},
             {from: './node_modules/ckeditor/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
-            {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'}
+            {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'},
+            {from: './node_modules/ckeditor/vendor', to: 'ckeditor/vendor/[path][name].[ext]'},            
         ])
         // Uncomment the following line if you are using Webpack Encore <= 0.24
         // .addLoader({test: /\.json$/i, include: [require('path').resolve(__dirname, 'node_modules/ckeditor')], loader: 'raw-loader', type: 'javascript/auto'})


### PR DESCRIPTION
The "vendor" folder with the"promise.js" file inside is not copied when building FOSCKEditor via webpack. 
We would get the following error in IE11: 'No route found for "GET /build/ckeditor/vendor/promise.js"'. Note: we are using FOSCKEditor with properties "autoload" & "auto_inline" set to "false".

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
