### PR TITLE
update webpack encore module name to ckeditor4

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,10 +61,10 @@ You can by running this command:
 .. code-block:: bash
 
     # if you are using NPM as package manager
-    $ npm install --save ckeditor@^4.0.0
+    $ npm install --save ckeditor4@^4.13.0
     
     # if you are using Yarn as package manager
-    $ yarn add ckeditor@^4.0.0
+    $ yarn add ckeditor4@^4.13.0
 
 Once installed, add the following lines to your Webpack Encore configuration file (this excludes the samples directory from the ckeditor node module):
 
@@ -76,11 +76,11 @@ Once installed, add the following lines to your Webpack Encore configuration fil
     Encore
         // ...
         .copyFiles([
-            {from: './node_modules/ckeditor/', to: 'ckeditor/[path][name].[ext]', pattern: /\.(js|css)$/, includeSubdirectories: false},
-            {from: './node_modules/ckeditor/adapters', to: 'ckeditor/adapters/[path][name].[ext]'},
-            {from: './node_modules/ckeditor/lang', to: 'ckeditor/lang/[path][name].[ext]'},
-            {from: './node_modules/ckeditor/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
-            {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'}
+            {from: './node_modules/ckeditor4/', to: 'ckeditor/[path][name].[ext]', pattern: /\.(js|css)$/, includeSubdirectories: false},
+            {from: './node_modules/ckeditor4/adapters', to: 'ckeditor/adapters/[path][name].[ext]'},
+            {from: './node_modules/ckeditor4/lang', to: 'ckeditor/lang/[path][name].[ext]'},
+            {from: './node_modules/ckeditor4/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
+            {from: './node_modules/ckeditor4/skins', to: 'ckeditor/skins/[path][name].[ext]'}
         ])
         // Uncomment the following line if you are using Webpack Encore <= 0.24
         // .addLoader({test: /\.json$/i, include: [require('path').resolve(__dirname, 'node_modules/ckeditor')], loader: 'raw-loader', type: 'javascript/auto'})


### PR DESCRIPTION
The CKEditor 4 node module name changed from `ckeditor` to `ckeditor4`, new releases will only be delivered on the later.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  /
| License       | MIT
