### PR TITLE
Fix base  url

### DIFF
--- a/src/Installer/CKEditorInstaller.php
+++ b/src/Installer/CKEditorInstaller.php
@@ -68,7 +68,7 @@ final class CKEditorInstaller
     /**
      * @var string
      */
-    private static $archive = 'https://github.com/ckeditor/ckeditor-releases/archive/%s/%s.zip';
+    private static $archive = 'https://github.com/ckeditor/ckeditor4-releases/archive/%s/%s.zip';
 
     /**
      * @var string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT

Since 04-20-2020 this error occured on `ckeditor:install --clear=drop`: 
`
# php bin/console ckeditor:install --clear=drop
----------------------
| CKEditor Installer |
----------------------

 // Downloading CKEditor ZIP archive from "https://github.com/ckeditor/ckeditor-releases/archive/full/latest.zip"


In CKEditorInstaller.php line 329:
                                                                                                                            
  Unable to download CKEditor ZIP archive from "https://github.com/ckeditor/ckeditor-releases/archive/full/latest.zip". (file_get_contents(https://github.com/ckeditor/ckeditor-releases/archive/full/latest.zip): failed to open stream: Connection timed out)
`

Removing redirect from https://github.com/ckeditor/ckeditor-releases to https://github.com/ckeditor/ckeditor4-releases fix this issue without causing BC Break.