### PR TITLE
make .gitattributes up to date

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,15 @@
 /docker export-ignore
-/travis export-ignore
+/.travis export-ignore
 /tests export-ignore
+/.github export-ignore
 .env.dist export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .php_cs export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
+.styleci.yml export-ignore
 CONTRIBUTING.md export-ignore
 appveyor.yml export-ignore
-docker-compose.yml export-ignore
 phpunit.xml.dist export-ignore
+phpstan.neon export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

added new file mentions
removed mention of non existing file (docker-compose.yml).

I think no one needs as a client(of the lib) what configs are used in `travis`/`phpstan`/`styleCI`/etc/
