### PR TITLE
ckeditor v4 package has been renamed to ckeditor4.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,10 +61,10 @@ You can by running this command:
 .. code-block:: bash
 
     # if you are using NPM as package manager
-    $ npm install --save ckeditor@^4.0.0
+    $ npm install --save ckeditor4@^4.0.0
     
     # if you are using Yarn as package manager
-    $ yarn add ckeditor@^4.0.0
+    $ yarn add ckeditor4@^4.0.0
 
 Once installed, add the following lines to your Webpack Encore configuration file (this excludes the samples directory from the ckeditor node module):
 
@@ -76,14 +76,14 @@ Once installed, add the following lines to your Webpack Encore configuration fil
     Encore
         // ...
         .copyFiles([
-            {from: './node_modules/ckeditor/', to: 'ckeditor/[path][name].[ext]', pattern: /\.(js|css)$/, includeSubdirectories: false},
-            {from: './node_modules/ckeditor/adapters', to: 'ckeditor/adapters/[path][name].[ext]'},
-            {from: './node_modules/ckeditor/lang', to: 'ckeditor/lang/[path][name].[ext]'},
-            {from: './node_modules/ckeditor/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
-            {from: './node_modules/ckeditor/skins', to: 'ckeditor/skins/[path][name].[ext]'}
+            {from: './node_modules/ckeditor4/', to: 'ckeditor/[path][name].[ext]', pattern: /\.(js|css)$/, includeSubdirectories: false},
+            {from: './node_modules/ckeditor4/adapters', to: 'ckeditor/adapters/[path][name].[ext]'},
+            {from: './node_modules/ckeditor4/lang', to: 'ckeditor/lang/[path][name].[ext]'},
+            {from: './node_modules/ckeditor4/plugins', to: 'ckeditor/plugins/[path][name].[ext]'},
+            {from: './node_modules/ckeditor4/skins', to: 'ckeditor/skins/[path][name].[ext]'}
         ])
         // Uncomment the following line if you are using Webpack Encore <= 0.24
-        // .addLoader({test: /\.json$/i, include: [require('path').resolve(__dirname, 'node_modules/ckeditor')], loader: 'raw-loader', type: 'javascript/auto'})
+        // .addLoader({test: /\.json$/i, include: [require('path').resolve(__dirname, 'node_modules/ckeditor4')], loader: 'raw-loader', type: 'javascript/auto'})
     ;
 
 Then, override the bundle's configuration to point to the new CKEditor path:


### PR DESCRIPTION
ckeditor v4 package has been renamed to ckeditor4.

> warning ckeditor@4.12.1: We have renamed the @ckeditor package. New versions are available under the @ckeditor4 name.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Fixed tickets | <!-- comma-separated list of tickets fixed by the PR, if any -->
| License       | MIT
