### PR TITLE
Update renamed ckeditor's github repository

### DIFF
--- a/src/Installer/CKEditorInstaller.php
+++ b/src/Installer/CKEditorInstaller.php
@@ -68,7 +68,7 @@ final class CKEditorInstaller
     /**
      * @var string
      */
-    private static $archive = 'https://github.com/ckeditor/ckeditor-releases/archive/%s/%s.zip';
+    private static $archive = 'https://github.com/ckeditor/ckeditor4-releases/archive/%s/%s.zip';
 
     /**
      * @var string


### PR DESCRIPTION
CKeditor renamed its release repository (ckeditor/ckeditor-releases -> ckeditor/ckeditor4-releases). The lib download was broken at first but a redirection has now been install fixing download. The PR propose to update repository url.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
