### PR TITLE
fix: activate lazyload for command listing

### DIFF
--- a/src/Command/CKEditorInstallerCommand.php
+++ b/src/Command/CKEditorInstallerCommand.php
@@ -28,6 +28,9 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  */
 final class CKEditorInstallerCommand extends Command
 {
+    protected static $defaultName = 'ckeditor:install';
+    protected static $defaultDescription = 'Install CKEditor';
+
     /**
      * @var CKEditorInstaller
      */


### PR DESCRIPTION
The docu is not up to date. There is a blog post about this, but could not find it at quick search.
https://symfony.com/doc/current/console/commands_as_services.html#console-command-service-lazy-loading
https://github.com/symfony/console/blob/5.4/Command/Command.php

I keept the 2 method calls in configure() for backward compatibility