### PR TITLE
chore: fix ci deprecations, add test for php 8.2, 8.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,13 @@ jobs:
                     - 7.4
                     - 8.0
                     - 8.1
+                    - 8.2
+                    - 8.3
                 dependencies: [highest]
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
@@ -31,7 +33,7 @@ jobs:
                   extensions: zip
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v2
               with:
                   dependency-versions: ${{ matrix.dependencies }}
                   composer-options: --prefer-dist


### PR DESCRIPTION
Updated for php 8.3