### PR TITLE
Add Symfony 7 support ; drop Symfony < 5.4 support and PHP < 8 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 .env.dist export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.php_cs export-ignore
+.php-cs-fixer.php export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
 .styleci.yml export-ignore

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,11 +14,12 @@ jobs:
                     - 8.0
                     - 8.1
                     - 8.2
+                    - 8.3
                 dependencies: [highest]
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,11 +11,9 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - 7.2
-                    - 7.3
-                    - 7.4
                     - 8.0
                     - 8.1
+                    - 8.2
                 dependencies: [highest]
 
         steps:
@@ -31,7 +29,7 @@ jobs:
                   extensions: zip
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v2
               with:
                   dependency-versions: ${{ matrix.dependencies }}
                   composer-options: --prefer-dist

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /.env
 
 # PHP CS Fixer
-/.php_cs.cache
+/.php-cs-fixer.cache
 
 # PHPUnit
 /build

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -16,12 +16,14 @@ $finder = Finder::create()
     ->in(__DIR__)
     ->exclude('vendor');
 
-return Config::create()
+$config = new Config();
+
+return $config
     ->setUsingCache(true)
     ->setRules([
-        '@Symfony'               => true,
-        'array_syntax'           => ['syntax' => 'short'],
-        'ordered_imports'        => true,
-        'yoda_style'             => false,
+        '@Symfony'        => true,
+        'array_syntax'    => ['syntax' => 'short'],
+        'ordered_imports' => true,
+        'yoda_style'      => false,
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -17,21 +17,21 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0",
         "ext-zip": "*",
         "ext-json": "*",
-        "symfony/asset": "^4.4 || ^5.0 || ^6.0",
-        "symfony/config": "^4.4 || ^5.0 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
-        "symfony/expression-language": "^4.4 || ^5.0 || ^6.0",
-        "symfony/form": "^4.4 || ^5.0 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
-        "symfony/options-resolver": "^4.4 || ^5.0 || ^6.0",
-        "symfony/property-access": "^4.4 || ^5.0 || ^6.0",
-        "symfony/routing": "^4.4 || ^5.0 || ^6.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0",
+        "symfony/asset": "^5.4 || ^6.0 || ^7.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/expression-language": "^5.4 || ^6.0 || ^7.0",
+        "symfony/form": "^5.4 || ^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",
+        "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
+        "symfony/routing": "^5.4 || ^6.0 || ^7.0",
+        "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
         "twig/twig": "^2.4 || ^3.0"
     },
     "conflict": {
@@ -39,11 +39,11 @@
         "sebastian/exporter": "<2.0.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.0",
-        "symfony/console": "^4.4 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.0 || ^6.0"
+        "friendsofphp/php-cs-fixer": "^3.41",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0 || ^5.0",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
         "egeloen/form-extra-bundle": "Allows to load CKEditor asynchronously"

--- a/src/Builder/JsonBuilder.php
+++ b/src/Builder/JsonBuilder.php
@@ -83,10 +83,7 @@ final class JsonBuilder
         return $this;
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function setValue(string $path, $value, bool $escapeValue = true): self
+    public function setValue(string $path, mixed $value, bool $escapeValue = true): self
     {
         if (!$escapeValue) {
             $placeholder = uniqid('friendsofsymfony', true);

--- a/src/Config/CKEditorConfiguration.php
+++ b/src/Config/CKEditorConfiguration.php
@@ -275,7 +275,7 @@ final class CKEditorConfiguration implements CKEditorConfigurationInterface
 
         foreach ($this->toolbarConfigs[$name] as $name => $item) {
             $items[] = is_string($item) && '@' === substr($item, 0, 1)
-                ? $this->toolbarItems[(substr($item, 1))]
+                ? $this->toolbarItems[substr($item, 1)]
                 : $item;
         }
 

--- a/src/Exception/BadProxyUrlException.php
+++ b/src/Exception/BadProxyUrlException.php
@@ -12,12 +12,10 @@
 
 namespace FOS\CKEditorBundle\Exception;
 
-use RuntimeException;
-
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */
-final class BadProxyUrlException extends RuntimeException implements FOSCKEditorException
+final class BadProxyUrlException extends \RuntimeException implements FOSCKEditorException
 {
     public static function fromEnvUrl(string $url): self
     {

--- a/src/Exception/ConfigException.php
+++ b/src/Exception/ConfigException.php
@@ -12,12 +12,10 @@
 
 namespace FOS\CKEditorBundle\Exception;
 
-use RuntimeException;
-
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-final class ConfigException extends RuntimeException implements FOSCKEditorException
+final class ConfigException extends \RuntimeException implements FOSCKEditorException
 {
     public static function configDoesNotExist(string $name): self
     {

--- a/src/Exception/FOSCKEditorException.php
+++ b/src/Exception/FOSCKEditorException.php
@@ -12,11 +12,9 @@
 
 namespace FOS\CKEditorBundle\Exception;
 
-use Throwable;
-
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-interface FOSCKEditorException extends Throwable
+interface FOSCKEditorException extends \Throwable
 {
 }

--- a/src/Installer/CKEditorInstaller.php
+++ b/src/Installer/CKEditorInstaller.php
@@ -21,49 +21,49 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class CKEditorInstaller
 {
-    const RELEASE_BASIC = 'basic';
+    public const RELEASE_BASIC = 'basic';
 
-    const RELEASE_FULL = 'full';
+    public const RELEASE_FULL = 'full';
 
-    const RELEASE_STANDARD = 'standard';
+    public const RELEASE_STANDARD = 'standard';
 
-    const RELEASE_CUSTOM = 'custom';
+    public const RELEASE_CUSTOM = 'custom';
 
-    const VERSION_LATEST = 'latest';
+    public const VERSION_LATEST = 'latest';
 
-    const CLEAR_DROP = 'drop';
+    public const CLEAR_DROP = 'drop';
 
-    const CLEAR_KEEP = 'keep';
+    public const CLEAR_KEEP = 'keep';
 
-    const CLEAR_SKIP = 'skip';
+    public const CLEAR_SKIP = 'skip';
 
-    const NOTIFY_CLEAR = 'clear';
+    public const NOTIFY_CLEAR = 'clear';
 
-    const NOTIFY_CLEAR_ARCHIVE = 'clear-archive';
+    public const NOTIFY_CLEAR_ARCHIVE = 'clear-archive';
 
-    const NOTIFY_CLEAR_COMPLETE = 'clear-complete';
+    public const NOTIFY_CLEAR_COMPLETE = 'clear-complete';
 
-    const NOTIFY_CLEAR_PROGRESS = 'clear-progress';
+    public const NOTIFY_CLEAR_PROGRESS = 'clear-progress';
 
-    const NOTIFY_CLEAR_QUESTION = 'clear-question';
+    public const NOTIFY_CLEAR_QUESTION = 'clear-question';
 
-    const NOTIFY_CLEAR_SIZE = 'clear-size';
+    public const NOTIFY_CLEAR_SIZE = 'clear-size';
 
-    const NOTIFY_DOWNLOAD = 'download';
+    public const NOTIFY_DOWNLOAD = 'download';
 
-    const NOTIFY_DOWNLOAD_COMPLETE = 'download-complete';
+    public const NOTIFY_DOWNLOAD_COMPLETE = 'download-complete';
 
-    const NOTIFY_DOWNLOAD_PROGRESS = 'download-progress';
+    public const NOTIFY_DOWNLOAD_PROGRESS = 'download-progress';
 
-    const NOTIFY_DOWNLOAD_SIZE = 'download-size';
+    public const NOTIFY_DOWNLOAD_SIZE = 'download-size';
 
-    const NOTIFY_EXTRACT = 'extract';
+    public const NOTIFY_EXTRACT = 'extract';
 
-    const NOTIFY_EXTRACT_COMPLETE = 'extract-complete';
+    public const NOTIFY_EXTRACT_COMPLETE = 'extract-complete';
 
-    const NOTIFY_EXTRACT_PROGRESS = 'extract-progress';
+    public const NOTIFY_EXTRACT_PROGRESS = 'extract-progress';
 
-    const NOTIFY_EXTRACT_SIZE = 'extract-size';
+    public const NOTIFY_EXTRACT_SIZE = 'extract-size';
 
     /**
      * @var string
@@ -306,16 +306,13 @@ final class CKEditorInstaller
         }
     }
 
-    /**
-     * @param mixed $data
-     *
-     * @return mixed
-     */
-    private function notify(callable $notifier = null, string $type, $data = null)
+    private function notify(callable $notifier = null, string $type = null, mixed $data = null): mixed
     {
         if (null !== $notifier) {
             return $notifier($type, $data);
         }
+
+        return null;
     }
 
     private function createException(string $message): \RuntimeException

--- a/tests/DependencyInjection/FOSCKEditorExtensionTest.php
+++ b/tests/DependencyInjection/FOSCKEditorExtensionTest.php
@@ -29,6 +29,7 @@ class FOSCKEditorExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
+     *
      * @expectedDeprecation IvoryCKEditorBundle isn't maintained anymore and should be replaced with FOSCKEditorBundle.
      */
     public function testIvoryDeprecation(): void

--- a/tests/Installer/CKEditorInstallerTest.php
+++ b/tests/Installer/CKEditorInstallerTest.php
@@ -262,13 +262,13 @@ class CKEditorInstallerTest extends TestCase
 
             case CKEditorInstaller::RELEASE_BASIC:
                 $this->assertFileExists($this->path.'/plugins/link');
-                $this->assertFileNotExists($this->path.'/plugins/image');
+                $this->assertFileDoesNotExist($this->path.'/plugins/image');
 
                 break;
 
             case CKEditorInstaller::RELEASE_STANDARD:
                 $this->assertFileExists($this->path.'/plugins/image');
-                $this->assertFileNotExists($this->path.'/plugins/copyformatting');
+                $this->assertFileDoesNotExist($this->path.'/plugins/copyformatting');
 
                 break;
         }
@@ -289,7 +289,7 @@ class CKEditorInstallerTest extends TestCase
     private function assertExcludes(array $excludes): void
     {
         foreach ($excludes as $exclude) {
-            $this->assertFileNotExists($this->path.'/'.$exclude);
+            $this->assertFileDoesNotExist($this->path.'/'.$exclude);
         }
     }
 }

--- a/tests/Installer/CKEditorInstallerTest.php
+++ b/tests/Installer/CKEditorInstallerTest.php
@@ -76,7 +76,7 @@ class CKEditorInstallerTest extends TestCase
 
     public function testInstallWithCustomBuild(): void
     {
-        $this->installer->install($options = ['release' => CKEditorInstaller::RELEASE_CUSTOM, 'custom_build_id' => '459c358ccf2e34f083e3c8847d3af23e']);
+        $this->installer->install($options = ['release' => CKEditorInstaller::RELEASE_CUSTOM, 'custom_build_id' => 'ffbb0c61721cb8543bfa54315374592d']);
 
         $this->assertInstall($options);
     }
@@ -86,7 +86,7 @@ class CKEditorInstallerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/Specifying version for custom build is not supported/');
 
-        $this->installer->install($options = ['release' => CKEditorInstaller::RELEASE_CUSTOM, 'custom_build_id' => '459c358ccf2e34f083e3c8847d3af23e', 'version' => '4.11.4']);
+        $this->installer->install(['release' => CKEditorInstaller::RELEASE_CUSTOM, 'custom_build_id' => 'ffbb0c61721cb8543bfa54315374592d', 'version' => '4.11.4']);
     }
 
     public function testInstallWithCustomBuildWithMissingId(): void
@@ -94,7 +94,7 @@ class CKEditorInstallerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/Custom build ID is not specified/');
 
-        $this->installer->install($options = ['release' => CKEditorInstaller::RELEASE_CUSTOM]);
+        $this->installer->install(['release' => CKEditorInstaller::RELEASE_CUSTOM]);
     }
 
     public function testInstallWithVersion(): void

--- a/tests/Renderer/CKEditorRendererTest.php
+++ b/tests/Renderer/CKEditorRendererTest.php
@@ -190,13 +190,15 @@ class CKEditorRendererTest extends TestCase
      */
     public function testRenderWidgetWithArrayContentsCss(array $paths, array $assets, array $urls): void
     {
+        $callMap = [];
         foreach (array_keys($paths) as $key) {
-            $this->packages
-                ->expects($this->at($key))
-                ->method('getUrl')
-                ->with($this->equalTo($paths[$key]))
-                ->will($this->returnValue($assets[$key]));
+            $callMap[] = [$paths[$key], null, $assets[$key]];
         }
+
+        $this->packages
+            ->expects($this->exactly(count($paths)))
+            ->method('getUrl')
+            ->willReturnMap($callMap);
 
         $this->assertSame(
             'CKEDITOR.replace("foo", {"contentsCss":'.json_encode($urls).'});',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #257 #234 #256 #235 #251 #252
| License       | MIT

Hi @lsmith77, I know this bundle might be in low-maintenance mode. But adding SF 7 support would be useful:
- I dropped PHP 7 support and SF 4 support since they are not maintained.
- I added SF 7 support
- I update Php-cs-fixer dependency
- I fixed the tests and solved the phpunit deprecations