### PR TITLE
Remove duplicate assignment in CKEditorConfiguration

### DIFF
--- a/src/Config/CKEditorConfiguration.php
+++ b/src/Config/CKEditorConfiguration.php
@@ -225,7 +225,6 @@ final class CKEditorConfiguration implements CKEditorConfigurationInterface
         $this->plugins = $config['plugins'];
         $this->styles = $config['styles'];
         $this->templates = $config['templates'];
-        $this->plugins = $config['plugins'];
         $this->configs = $config['configs'];
         $this->toolbarConfigs = array_merge($this->toolbarConfigs, $config['toolbars']['configs']);
         $this->toolbarItems = array_merge($this->toolbarItems, $config['toolbars']['items']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT

This PR removes a double assignment that seems redundant.