### PR TITLE
feat: only use symfony/phpunit-bridge v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "friendsofphp/php-cs-fixer": "^3.41",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0 || ^5.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^7.0",
+        "symfony/phpunit-bridge": "^6.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "friendsofphp/php-cs-fixer": "^3.41",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0 || ^5.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^7.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {


### PR DESCRIPTION
Try to fix https://github.com/FriendsOfSymfony/FOSCKEditorBundle/actions/runs/11956353908/job/33330902465?pr=265

`PHP Fatal error:  Declaration of PHPUnit\Framework\TestSuite::run(): void must be compatible with PHPUnit\Framework\Test::run(?PHPUnit\Framework\TestResult $result = null): PHPUnit\Framework\TestResult in /home/runner/work/FOSCKEditorBundle/FOSCKEditorBundle/vendor/phpunit/phpunit/src/Framework/TestSuite.php on line 332`