### PR TITLE
Fix deprecated on php 8.4

### DIFF
--- a/src/Command/CKEditorInstallerCommand.php
+++ b/src/Command/CKEditorInstallerCommand.php
@@ -290,8 +290,8 @@ EOF
     private function block(
         string $message,
         OutputInterface $output,
-        string $background = null,
-        string $font = null
+        ?string $background = null,
+        ?string $font = null
     ): void {
         $options = [];
 


### PR DESCRIPTION
FOS\CKEditorBundle\Command\CKEditorInstallerCommand::block(): Implicitly marking parameter $background as nullable is deprecated, the explicit nullable type must be used instead

FOS\CKEditorBundle\Command\CKEditorInstallerCommand::block(): Implicitly marking parameter $font as nullable is deprecated, the explicit nullable type must be used instead

| Q             | A
| ------------- | ---
| Deprecations? | yes
