### PR TITLE
prevent PHPUnit 10 from being installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.41",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0 || ^5.0",
+        "phpunit/phpunit": "^9.6",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Since 5.2 the matthiasnoback/symfony-config-test package as a requirement for phpunit/phpunit. As we are using PHPUnit 9.6 to run tests we need to make sure that we do not get conflicting versions of the same package.